### PR TITLE
Update task runner to allow multi-threading on OSX

### DIFF
--- a/Interlace/lib/threader.py
+++ b/Interlace/lib/threader.py
@@ -1,4 +1,5 @@
 import threading
+import subprocess
 import os
 
 
@@ -20,7 +21,7 @@ class Worker(object):
 
     @staticmethod
     def run_task(task):
-        os.system(task)
+        subprocess.call(task, shell=true)
 
 
 class Pool(object):


### PR DESCRIPTION
Fixes bug #36. 
I think the issue is the original method "shares" the shell that is used by all the workers and therefore blocks other calls to that shell (forcing it to be synchronous). Using subprocess.call() with the shell=true is pretty much allowing each worker to spawn their own instance of a shell.